### PR TITLE
Drop 4 unneeded deps, bump to 2.1

### DIFF
--- a/api/admin/index.js
+++ b/api/admin/index.js
@@ -1,14 +1,12 @@
 const {User} = require('../db/models/user.model')
-const _ = require("lodash");
 
 // REQUIRES ADMIN
 const getUserList = async (req, res) => {
     const u = await User.find()
 
-    const filtered = []
-    _.forEach(u, function (val) {
-        filtered.push(_.pick(val, ['_id', 'name', 'master', 'admin', 'character']))
-    })
+    const filtered = u.map((val) => ({
+        _id: val._id, name: val.name, master: val.master, admin: val.admin, character: val.character
+    }))
 
     res.send(filtered)
 }

--- a/api/character/index.js
+++ b/api/character/index.js
@@ -1,6 +1,5 @@
 const {User} = require('../db/models/user.model')
 const {Character} = require('../db/models/character.model')
-const _ = require('lodash')
 const mongoose = require('mongoose')
 const fs = require('fs')
 const path = require('path')
@@ -431,13 +430,16 @@ const deleteOwnCharacter = async (req, res) => {
 // List views don't need the attachment metadata, so keep their (leaner) shape;
 // only the single-character sheet GET carries `attachment`.
 const filterCharacterListe = (liste) => {
-    return _.map(liste, (item) => {
-        return _.pick(item, ['_id', 'character', 'npc', 'primary'])
-    })
+    return liste.map((item) => ({
+        _id: item._id, character: item.character, npc: item.npc, primary: item.primary
+    }))
 }
 
 const filterCharacter = (char) => {
-    return _.pick(char, ['_id', 'character', 'npc', 'primary', 'attachment'])
+    return {
+        _id: char._id, character: char.character, npc: char.npc,
+        primary: char.primary, attachment: char.attachment
+    }
 }
 
 const isOwnedByUser = (character, id) => {

--- a/api/db/models/user.model.js
+++ b/api/db/models/user.model.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 const bcrypt = require("bcrypt");
-const {v4: uuidv4} = require('uuid');
+const {randomUUID} = require('crypto');
 
 //Define a schema
 const UserSchema = new mongoose.Schema({
@@ -48,7 +48,7 @@ UserSchema.pre('save', function (next) {
 UserSchema.methods.generateSession = async function () {
     const user = this
 
-    const id = uuidv4()
+    const id = randomUUID()
 
     user.session.push({token: id})
     await user.save()

--- a/api/encounter/index.js
+++ b/api/encounter/index.js
@@ -1,4 +1,3 @@
-const _ = require("lodash");
 const {Monster} = require("../db/models/monster.model");
 const {Encounter} = require("../db/models/encounter.model");
 const mongoose = require("mongoose");

--- a/api/initiative/index.js
+++ b/api/initiative/index.js
@@ -1,5 +1,3 @@
-const _ = require('lodash')
-
 let master = []
 let player = []
 let round = 1
@@ -66,7 +64,10 @@ const deleteAllMaster = (req, res) => {
     playerTurn = 0
     round = 1
     colorMarkerIndex = 0
-    colorMarkers = _.shuffle(colorMarkers)
+    for (let i = colorMarkers.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [colorMarkers[i], colorMarkers[j]] = [colorMarkers[j], colorMarkers[i]]
+    }
     res.sendStatus(200)
 }
 
@@ -272,7 +273,7 @@ const prevTurn = (req, res) => {
 }
 
 const updatePlayerData = () => {
-    const temp = _.cloneDeep(master)
+    const temp = structuredClone(master)
     playerTurn = turn
     // Set whos turn it is + master to false
     for (let i = 0; i < temp.length; i++) {
@@ -288,7 +289,7 @@ const updatePlayerData = () => {
             }
         }
     }
-    player = _.cloneDeep(temp)
+    player = structuredClone(temp)
 }
 
 module.exports = {

--- a/api/monster/index.js
+++ b/api/monster/index.js
@@ -1,4 +1,3 @@
-const _ = require("lodash");
 const {Monster} = require("../db/models/monster.model");
 const {Character} = require("../db/models/character.model");
 
@@ -51,13 +50,12 @@ const getMonster = async (req, res) => {
 //
 
 const filterMonsterListe = (liste) => {
-    return _.map(liste, (item) => {
-        return filterMonster(item)
-    })
+    return liste.map((item) => filterMonster(item))
 }
 
 const filterMonster = (char) => {
-    return _.omit(char.toObject(), ['__v'])
+    const {__v, ...rest} = char.toObject()
+    return rest
 }
 
 module.exports = {

--- a/api/package.json
+++ b/api/package.json
@@ -9,10 +9,8 @@
     "express": "^4.22.2",
     "express-rate-limit": "^8.5.2",
     "express-session": "^1.19.0",
-    "lodash": "^4.18.1",
     "mongoose": "^8.24.1",
-    "multer": "^2.2.0",
-    "uuid": "^11.1.1"
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "jest": "^30.4.2",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "2.0",
+  "version": "2.1",
   "private": true,
   "license": "MIT",
   "dependencies": {

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2459,11 +2459,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@^4.18.1:
-  version "4.18.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
-  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
-
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -3486,11 +3481,6 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
-
-uuid@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
-  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"

--- a/e2e/tests/settings.spec.ts
+++ b/e2e/tests/settings.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test'
 import {apiContext, login} from './helpers'
+import {version} from '../../web/package.json'
 
 // Mint a throwaway user (via the admin API) so password / account changes don't
 // pollute the shared fixtures.
@@ -80,6 +81,6 @@ test.describe('settings (account self-service)', () => {
     test('shows the current app version', async ({page}) => {
         await login(page)
         await page.goto('/settings')
-        await expect(page.getByText(/Version:\s*2\.0/)).toBeVisible()
+        await expect(page.getByText(`Version: ${version}`)).toBeVisible()
     })
 })

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd",
-  "version": "2.0",
+  "version": "2.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@react-icons/all-files": "^4.1.0",
     "@types/node": "^20.11.27",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
@@ -19,10 +18,8 @@
     "axios": "^1.6.7",
     "formik": "^2.2.9",
     "framer-motion": "^11.0.13",
-    "lodash": "^4.18.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-helmet-async": "^2.0.4",
     "react-icons": "~5.3.0",
     "react-router-dom": "^6.1.1",
     "typescript": "^4.5.4"
@@ -36,7 +33,6 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
-    "@types/lodash": "^4.17.24",
     "@vitejs/plugin-react": "^6.0.3",
     "jsdom": "^25.0.1",
     "vite": "^8.1.2",

--- a/web/src/Pages/encounter/encounter-entry.tsx
+++ b/web/src/Pages/encounter/encounter-entry.tsx
@@ -27,7 +27,6 @@ import {
     Tr,
     useToast
 } from "@chakra-ui/react"
-import _ from "lodash";
 import {AddIcon, DeleteIcon, EditIcon, ViewOffIcon} from "@chakra-ui/icons";
 import {IoSaveSharp} from "react-icons/io5";
 import axios from "axios";
@@ -59,7 +58,7 @@ const App = (props: { m: EncounterType, u: () => void, e: boolean }) => {
 
     const addMonster = () => {
         if (monster !== "") {
-            let temp: EncounterType = _.cloneDeep(encounter)
+            let temp: EncounterType = structuredClone(encounter)
             temp.encounter.push(newEncounterRow(monster, monsterList, hide, amount))
             setEncounter(temp)
         }

--- a/web/src/Pages/encounter/encounter-list.tsx
+++ b/web/src/Pages/encounter/encounter-list.tsx
@@ -5,8 +5,7 @@ import axios from "axios";
 import {AddIcon} from "@chakra-ui/icons";
 import TitleService from "../../Service/titleService";
 import {Text} from "@chakra-ui/react";
-import {AiOutlineArrowLeft} from "@react-icons/all-files/ai/AiOutlineArrowLeft";
-import {AiOutlineArrowRight} from "@react-icons/all-files/ai/AiOutlineArrowRight";
+import {AiOutlineArrowLeft, AiOutlineArrowRight} from "react-icons/ai";
 import {EncounterType} from "./encounter.type";
 import EncounterEntry from "./encounter-entry";
 

--- a/web/src/Pages/initiative/add/add-encounter.tsx
+++ b/web/src/Pages/initiative/add/add-encounter.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import {Center, Input, Table, Tbody, Td, Text, Th, Thead, Tr} from "@chakra-ui/react";
 import {AddIcon} from "@chakra-ui/icons";
 import "../initiative.css";
-import _ from "lodash";
 import axios from "axios";
 import {EncounterMonster, EncounterType} from "../../encounter/encounter.type";
 import {buildEncounterInstances, monsterBoardEntry} from "./add.utils";
@@ -14,7 +13,7 @@ const App = (props: {u: () => void}) => {
 
     const search = (val: string) => {
         // @ts-ignore — encounter rows carry a `name`, not a `character.name`
-        setValue(_.cloneDeep(data.filter(d => (d.name || '').toLowerCase().includes(val.toLowerCase()))))
+        setValue(structuredClone(data.filter(d => (d.name || '').toLowerCase().includes(val.toLowerCase()))))
     }
 
     const getMonster = () => {

--- a/web/src/Pages/initiative/add/add-monster.tsx
+++ b/web/src/Pages/initiative/add/add-monster.tsx
@@ -3,7 +3,6 @@ import {Center, Input, Switch, Table, Tbody, Td, Text, Th, Thead, Tr} from "@cha
 import {AddIcon} from "@chakra-ui/icons";
 import "../initiative.css";
 import {Player} from "../player.type";
-import _ from "lodash";
 import axios from "axios";
 import {Monster} from "../../monster/monster.type";
 import {abilityModifier, applyHidden, filterByName, monsterBoardEntry, rollD20} from "./add.utils";
@@ -14,7 +13,7 @@ const App = (props: {u: () => void}) => {
     const [values, setValue] = useState<Player[]>([])
 
     const search = (val: string) => {
-        setValue(_.cloneDeep(filterByName(data, val)))
+        setValue(structuredClone(filterByName(data, val)))
     }
 
     const getMonster = () => {

--- a/web/src/Pages/initiative/add/add-npc.tsx
+++ b/web/src/Pages/initiative/add/add-npc.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import {Center, Input, Switch, Table, Tbody, Td, Text, Th, Thead, Tr} from "@chakra-ui/react"
 import {AddIcon} from "@chakra-ui/icons";
 import "../initiative.css";
-import _ from "lodash";
 import {Player} from "../player.type";
 import axios from "axios";
 import {abilityModifier, applyHidden, colorToMarker, filterByName, npcEntries, rollD20} from "./add.utils";
@@ -13,7 +12,7 @@ const App = (props: {u: () => void}) => {
     const [values, setValue] = useState<Player[]>([])
 
     const search = (val: string) => {
-        setValue(_.cloneDeep(filterByName(data, val)))
+        setValue(structuredClone(filterByName(data, val)))
     }
 
     const getPlayer = () => {

--- a/web/src/Pages/initiative/add/add-player.tsx
+++ b/web/src/Pages/initiative/add/add-player.tsx
@@ -16,7 +16,6 @@ import {
 } from "@chakra-ui/react"
 import {AddIcon} from "@chakra-ui/icons";
 import "../initiative.css";
-import _ from "lodash";
 import {Player} from "../player.type";
 import axios from "axios";
 import {colorToMarker, filterByName, playableEntries} from "./add.utils";
@@ -27,7 +26,7 @@ const App = (props: {u: () => void}) => {
     const [values, setValue] = useState<Player[]>([])
 
     const search = (val: string) => {
-        setValue(_.cloneDeep(filterByName(data, val)))
+        setValue(structuredClone(filterByName(data, val)))
     }
 
     const getPlayer = () => {

--- a/web/src/Pages/initiative/add/add.utils.ts
+++ b/web/src/Pages/initiative/add/add.utils.ts
@@ -3,7 +3,6 @@
 // roll, colour mapping and encounter expansion can be unit-tested without
 // rendering the axios-driven modal components.
 
-import _ from "lodash";
 import {Player} from "../player.type";
 import {EncounterType} from "../../encounter/encounter.type";
 
@@ -89,7 +88,7 @@ export const buildEncounterInstances = (encounter: EncounterType, roll: () => nu
     const out: Player[] = []
     encounter.encounter.forEach(group => {
         for (let i = 0; i < group.amount; i++) {
-            const data: Player | undefined = group.data ? _.cloneDeep(group.data) : undefined
+            const data: Player | undefined = group.data ? structuredClone(group.data) : undefined
             if (data && data.character && data.character.dex) {
                 data.initiative = abilityModifier(data.character.dex) + roll()
             }

--- a/web/src/Pages/initiative/initiative-entry.utils.test.ts
+++ b/web/src/Pages/initiative/initiative-entry.utils.test.ts
@@ -6,6 +6,7 @@ import {
     calcHp,
     calcMaxHp,
     canSeeHp,
+    deepEqual,
     formatSave,
     isDead,
     isRowHiddenFromPlayer,
@@ -176,5 +177,22 @@ describe('markerColor', () => {
     it('returns empty string for NONE and out-of-range values', () => {
         expect(markerColor(ColorMarkerEnum.NONE)).toBe('')
         expect(markerColor(999 as ColorMarkerEnum)).toBe('')
+    })
+})
+
+describe('deepEqual', () => {
+    it('treats value-identical entries as equal regardless of key order', () => {
+        expect(deepEqual({name: 'Aria', hp: '10'}, {hp: '10', name: 'Aria'})).toBe(true)
+    })
+
+    it('recurses into nested objects', () => {
+        expect(deepEqual({s: {dex: 3}}, {s: {dex: 3}})).toBe(true)
+        expect(deepEqual({s: {dex: 3}}, {s: {dex: 4}})).toBe(false)
+    })
+
+    it('detects differing values, extra keys, and missing keys', () => {
+        expect(deepEqual({hp: '10'}, {hp: '9'})).toBe(false)
+        expect(deepEqual({hp: '10'}, {hp: '10', temp: '2'})).toBe(false)
+        expect(deepEqual({hp: '10', temp: '2'}, {hp: '10'})).toBe(false)
     })
 })

--- a/web/src/Pages/initiative/initiative-entry.utils.ts
+++ b/web/src/Pages/initiative/initiative-entry.utils.ts
@@ -101,6 +101,20 @@ export const isRowHiddenFromPlayer = (isMaster: boolean, hidden: boolean): boole
 export const canSeeHp = (npc: boolean, isMaster: boolean, shareHp: boolean): boolean =>
     !npc || isMaster || shareHp
 
+// Order-insensitive deep equality for the JSON-shaped Player entries the board
+// polls (replacing lodash _.isEqual). Key order must not matter: an entry the
+// master rewrites can serialize its keys in a different order without changing
+// values, and a plain JSON.stringify compare would flag that as a change and
+// flicker the board.
+export const deepEqual = (a: any, b: any): boolean => {
+    if (a === b) return true
+    if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false
+    const ka = Object.keys(a)
+    const kb = Object.keys(b)
+    if (ka.length !== kb.length) return false
+    return ka.every(k => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]))
+}
+
 // CSS colour for a marker enum; NONE / out-of-range → '' (no marker shown).
 export const markerColor = (color: ColorMarkerEnum): string => {
     switch (color) {

--- a/web/src/Pages/initiative/initiative.tsx
+++ b/web/src/Pages/initiative/initiative.tsx
@@ -19,6 +19,7 @@ import {DndContext, DragEndEvent, PointerSensor, closestCenter, useSensor, useSe
 import {SortableContext, arrayMove, verticalListSortingStrategy} from "@dnd-kit/sortable";
 import "./initiative.css";
 import { flushSync } from "react-dom";
+import {deepEqual} from "./initiative-entry.utils";
 import {Player} from "./player.type";
 import axios from "axios";
 import Add from "./add/add";
@@ -72,7 +73,7 @@ const App = () => {
                 flushSync(() => setPlayer(newPlayer))
             } else {
                 for (let i = 0; i < player.length; i++) {
-                    if (JSON.stringify(player[i]) !== JSON.stringify(newPlayer[i])) {
+                    if (!deepEqual(player[i], newPlayer[i])) {
                         flushSync(() => setPlayer([]))
                         flushSync(() => setPlayer(newPlayer))
                         break

--- a/web/src/Pages/initiative/initiative.tsx
+++ b/web/src/Pages/initiative/initiative.tsx
@@ -21,7 +21,6 @@ import "./initiative.css";
 import { flushSync } from "react-dom";
 import {Player} from "./player.type";
 import axios from "axios";
-import _ from "lodash";
 import Add from "./add/add";
 import TitleService from "../../Service/titleService";
 import {accordionIndexOnTurn} from "./initiative-entry.utils";
@@ -73,7 +72,7 @@ const App = () => {
                 flushSync(() => setPlayer(newPlayer))
             } else {
                 for (let i = 0; i < player.length; i++) {
-                    if (!_.isEqual(player[i], newPlayer[i])) {
+                    if (JSON.stringify(player[i]) !== JSON.stringify(newPlayer[i])) {
                         flushSync(() => setPlayer([]))
                         flushSync(() => setPlayer(newPlayer))
                         break

--- a/web/src/Pages/monster/monster-entry.tsx
+++ b/web/src/Pages/monster/monster-entry.tsx
@@ -33,7 +33,6 @@ import {
     Tr,
     useToast
 } from "@chakra-ui/react"
-import _ from "lodash";
 import {DeleteIcon, EditIcon} from "@chakra-ui/icons";
 import {IoSaveSharp} from "react-icons/io5";
 import axios from "axios";
@@ -77,8 +76,8 @@ const App = (props: { m: Monster, u: () => void, e: boolean }) => {
     }
 
     const updateEntryStat = (key: number, val: number) => {
-        const temp = _.cloneDeep(entry)
-        const tempMon = _.cloneDeep(monster)
+        const temp = structuredClone(entry)
+        const tempMon = structuredClone(monster)
 
         // @ts-ignore
         tempMon.monster.stats[temp[key].stat.toLowerCase()] = val
@@ -92,8 +91,8 @@ const App = (props: { m: Monster, u: () => void, e: boolean }) => {
     }
 
     const updateEntrySave = (key: number, val: number) => {
-        const temp = _.cloneDeep(entry)
-        const tempMon = _.cloneDeep(monster)
+        const temp = structuredClone(entry)
+        const tempMon = structuredClone(monster)
 
         // @ts-ignore
         tempMon.monster.saving[temp[key].stat.toLowerCase()] = val
@@ -104,7 +103,7 @@ const App = (props: { m: Monster, u: () => void, e: boolean }) => {
     }
 
     const updateMonster = (key: string, val: string) => {
-        const tempMon = _.cloneDeep(monster)
+        const tempMon = structuredClone(monster)
 
         // @ts-ignore
         tempMon.monster[key] = val

--- a/web/src/Pages/monster/monster-list.tsx
+++ b/web/src/Pages/monster/monster-list.tsx
@@ -7,8 +7,7 @@ import axios from "axios";
 import {AddIcon} from "@chakra-ui/icons";
 import TitleService from "../../Service/titleService";
 import {Text} from "@chakra-ui/react";
-import {AiOutlineArrowLeft} from "@react-icons/all-files/ai/AiOutlineArrowLeft";
-import {AiOutlineArrowRight} from "@react-icons/all-files/ai/AiOutlineArrowRight";
+import {AiOutlineArrowLeft, AiOutlineArrowRight} from "react-icons/ai";
 
 const App = () => {
 

--- a/web/src/Service/titleService.tsx
+++ b/web/src/Service/titleService.tsx
@@ -1,15 +1,12 @@
-import React from 'react'
-import {Helmet, HelmetProvider} from "react-helmet-async";
+import {useEffect} from 'react'
 
 const TitleService = (props: { title: string }) => {
 
-    return (
-        <HelmetProvider>
-            <Helmet>
-                <title>{props.title} | D&D Companion</title>
-            </Helmet>
-        </HelmetProvider>
-    )
+    useEffect(() => {
+        document.title = `${props.title} | D&D Companion`
+    }, [props.title])
+
+    return null
 }
 
 export default TitleService

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -4,38 +4,11 @@ import './index.css';
 import App from "./App";
 import {ChakraProvider} from '@chakra-ui/react';
 import "./Service/api";
-import {Helmet, HelmetProvider} from "react-helmet-async";
 
 const root = createRoot(document.getElementById('root')!)
 
 root.render(
     <React.StrictMode>
-
-        <HelmetProvider>
-            <Helmet>
-                {/*Primary Meta Tags*/}
-                <title>D&D Companion</title>
-                <meta name="title" content="D&D Companion"/>
-                <meta name="description" content="This is a private D&D Companion used in our home game"/>
-
-                {/*Open Graph / Facebook*/}
-                <meta property="og:type" content="website"/>
-                <meta property="og:url" content="https://dnd.bschwarz.dev/"/>
-                <meta property="og:title" content="D&D Companion"/>
-                <meta property="og:description"
-                      content="This is a private D&D Companion used in our home game"/>
-                <meta property="og:image" content=""/>
-
-                {/*Twitter*/}
-                <meta property="twitter:card" content="summary_large_image"/>
-                <meta property="twitter:url" content="https://dnd.bschwarz.dev/"/>
-                <meta property="twitter:title" content="D&D Companion"/>
-                <meta property="twitter:description"
-                      content="This is a private D&D Companion used in our home game"/>
-                <meta property="twitter:image" content=""/>
-            </Helmet>
-        </HelmetProvider>
-
         <ChakraProvider>
             <App/>
         </ChakraProvider>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -404,11 +404,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@react-icons/all-files@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@react-icons/all-files/-/all-files-4.1.0.tgz#477284873a0821928224b6fc84c62d2534d6650b"
-  integrity sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==
-
 "@remix-run/router@1.23.3":
   version "1.23.3"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
@@ -582,7 +577,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*", "@types/lodash@^4.17.24":
+"@types/lodash@*":
   version "4.17.24"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.24.tgz#4ae334fc62c0e915ca8ed8e35dcc6d4eeb29215f"
   integrity sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==
@@ -1313,13 +1308,6 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
-
 is-arguments@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
@@ -1583,12 +1571,12 @@ lodash.mergewith@4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
-lodash@^4.17.21, lodash@^4.18.1:
+lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -1807,7 +1795,7 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-fast-compare@3.2.2, react-fast-compare@^3.2.2:
+react-fast-compare@3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"
   integrity sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==
@@ -1828,15 +1816,6 @@ react-focus-lock@^2.9.6:
     react-clientside-effect "^1.2.7"
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.3"
-
-react-helmet-async@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/react-helmet-async/-/react-helmet-async-2.0.5.tgz#cfc70cd7bb32df7883a8ed55502a1513747223ec"
-  integrity sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==
-  dependencies:
-    invariant "^2.2.4"
-    react-fast-compare "^3.2.2"
-    shallowequal "^1.1.0"
 
 react-icons@~5.3.0:
   version "5.3.0"
@@ -2020,11 +1999,6 @@ set-function-name@^2.0.2:
     es-errors "^1.3.0"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
-
-shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 side-channel-list@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary
Cut four dependencies in favor of stdlib/native equivalents. No behavior change; version bumped to 2.1.

- **lodash** (api + web + `@types/lodash`) — `cloneDeep`→`structuredClone`; `pick`/`omit`/`map`/`forEach`→destructuring + Array methods; `shuffle`→inline Fisher-Yates; `isEqual`→order-insensitive `deepEqual` helper. Removed a dead `require` in `encounter/index.js`.
- **uuid** (api) — `crypto.randomUUID`.
- **react-helmet-async** (web) — static meta already lives in `web/index.html`; dropped the duplicate block in `index.tsx`; `TitleService` now sets `document.title` in a `useEffect`.
- **@react-icons/all-files** (web) — the 2 icons now import from `react-icons/ai` (`react-icons` already a dep).

## Review follow-up
A `/code-review` (max) flagged that swapping `_.isEqual` for a `JSON.stringify` compare in the initiative poll was key-order-sensitive → could flicker the board after a master edit. Replaced with a unit-tested order-insensitive `deepEqual` in `initiative-entry.utils.ts`.

## Testing
- API: 116/116 (jest)
- Web: 109→112 (vitest, +3 deepEqual cases)
- `tsc` + `vite build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)