### PR TITLE
perf: strip base64 sheet images from initiative + list payloads (2.2)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -93,6 +93,7 @@ Start the server by first installing all modules with ``npm install`` and then r
 |-------------------|:--------:|:---------------------------------------:|:--------------------:|--------------------------------|-------------------------------------|
 | /api/monster/new  |  `GET`   |                 `none`                  | `master` | Creates a new monster          | `none`                              |
 | /api/monster/list |  `GET`   |                 `none`                  | `master` | Returns a list of all monsters | `[{_id:ObjectID, monster:Monster}]` |
+| /api/monster/list/lean |  `GET`   |                 `none`                  | `master` | Like `/list` but only the board subset (name, ac, hp, speed, stats.dex, saving) — for the add-monster modal & encounter picker | `[{_id:ObjectID, monster:{name,ac,hp,speed,stats:{dex},saving}}]` |
 | /api/monster      |  `PUT`   | `charID:ObjectID`<br/>`monster:Monster` | `master` | Updates a monster              | `none`                              |
 | /api/monster/:id  | `DELETE` |                 `none`                  | `master` | Deletes a monster              | `none`                              |
 | /api/monster/:id  |  `GET`   |                 `none`                  | `master` | Returns the specified monster  | `[{_id:ObjectID, monster:Monster}]` |

--- a/api/__tests__/character.test.js
+++ b/api/__tests__/character.test.js
@@ -132,7 +132,7 @@ describe('HP endpoints', () => {
 describe('character lists', () => {
     test('getCharacterList excludes the requester’s own; getOwnCharacterList returns only theirs', async () => {
         await seedActors()
-        const mine = await makeCharacter({owner: player, character: {name: 'Mine', hp: 12, appearance: 'data:image/png;base64,AAAA'}})
+        const mine = await makeCharacter({owner: player, character: {name: 'Mine', hp: 12, playerName: 'Owner', appearance: 'data:image/png;base64,AAAA'}})
         const theirs = await makeCharacter({owner: other, character: {name: 'Theirs'}})
         const agent = await loginAgent(app, 'player')
         // player is a plain user, so use gm (master/admin) for the privileged list,
@@ -146,9 +146,11 @@ describe('character lists', () => {
         expect(names).toContain('Theirs')
         expect(names).not.toContain('GMs') // requester's own excluded
         list.forEach(c => expect(Object.keys(c).sort()).toEqual(['_id', 'character', 'npc', 'primary']))
-        // list ships only the board subset, never the heavy base64 image
+        // list keeps the board subset + the list-view display fields, but never
+        // the heavy base64 image
         const mineOut = list.find(c => c.character.name === 'Mine')
         expect(mineOut.character.hp).toBe(12)
+        expect(mineOut.character.playerName).toBe('Owner') // character-list "Spieler" column
         expect(mineOut.character).not.toHaveProperty('appearance')
 
         const own = (await agent.get('/api/charlist/me')).body

--- a/api/__tests__/character.test.js
+++ b/api/__tests__/character.test.js
@@ -132,7 +132,7 @@ describe('HP endpoints', () => {
 describe('character lists', () => {
     test('getCharacterList excludes the requester’s own; getOwnCharacterList returns only theirs', async () => {
         await seedActors()
-        const mine = await makeCharacter({owner: player, character: {name: 'Mine'}})
+        const mine = await makeCharacter({owner: player, character: {name: 'Mine', hp: 12, appearance: 'data:image/png;base64,AAAA'}})
         const theirs = await makeCharacter({owner: other, character: {name: 'Theirs'}})
         const agent = await loginAgent(app, 'player')
         // player is a plain user, so use gm (master/admin) for the privileged list,
@@ -146,6 +146,10 @@ describe('character lists', () => {
         expect(names).toContain('Theirs')
         expect(names).not.toContain('GMs') // requester's own excluded
         list.forEach(c => expect(Object.keys(c).sort()).toEqual(['_id', 'character', 'npc', 'primary']))
+        // list ships only the board subset, never the heavy base64 image
+        const mineOut = list.find(c => c.character.name === 'Mine')
+        expect(mineOut.character.hp).toBe(12)
+        expect(mineOut.character).not.toHaveProperty('appearance')
 
         const own = (await agent.get('/api/charlist/me')).body
         expect(own.map(c => c.character.name)).toEqual(['Mine'])

--- a/api/__tests__/initiative.test.js
+++ b/api/__tests__/initiative.test.js
@@ -83,6 +83,21 @@ describe('addMaster', () => {
         expect(markers[10]).toBe(1) // wrapped
     })
 
+    test('strips the base64 image (and other non-board fields) from the stored entry', () => {
+        init.addMaster({body: {player: mkPlayer({
+            character: {name: 'Hero', hp: 12, ac: '15', dexSave: '3',
+                appearance: 'data:image/png;base64,' + 'A'.repeat(50000),
+                spells: ['a', 'b'], inventory: 'lots'}
+        })}}, mockRes())
+        const {character} = masterView().player[0]
+        expect(character.name).toBe('Hero')
+        expect(character.hp).toBe(12)
+        expect(character.dexSave).toBe('3')
+        expect(character).not.toHaveProperty('appearance')
+        expect(character).not.toHaveProperty('spells')
+        expect(character).not.toHaveProperty('inventory')
+    })
+
     test('missing player is a silent no-op (still 200)', () => {
         const res = mockRes()
         init.addMaster({body: {}}, res)

--- a/api/__tests__/monster-encounter.test.js
+++ b/api/__tests__/monster-encounter.test.js
@@ -58,6 +58,23 @@ describe('monster', () => {
         expect(names).toEqual([...names].sort())
     })
 
+    test('lean list keeps the board subset but drops the heavy text fields', async () => {
+        await seed()
+        await Monster.create({monster: {
+            name: 'Beholder', ac: '18', hp: '180', speed: '0 ft., fly 20 ft.',
+            stats: {dex: 14, str: 10}, saving: {dex: 5, con: 6},
+            actions: 'a very long block of action text '.repeat(50),
+            senses: 'darkvision 120 ft.', languages: 'Deep Speech, Undercommon'
+        }})
+        const m = (await gm.get('/api/monster/list/lean')).body.find(x => x.monster.name === 'Beholder')
+        expect(m.monster.hp).toBe('180')
+        expect(m.monster.stats.dex).toBe(14)
+        expect(m.monster.saving.dex).toBe(5)
+        expect(m.monster).not.toHaveProperty('actions')
+        expect(m.monster).not.toHaveProperty('senses')
+        expect(m.monster).not.toHaveProperty('languages')
+    })
+
     // Monster is a master-only tab: every route (including list) requires the
     // master flag — a plain user and an admin-without-master are both rejected.
     test('non-masters cannot use any monster route (401)', async () => {

--- a/api/character/index.js
+++ b/api/character/index.js
@@ -427,11 +427,23 @@ const deleteOwnCharacter = async (req, res) => {
     res.sendStatus(200)
 }
 
-// List views don't need the attachment metadata, so keep their (leaner) shape;
-// only the single-character sheet GET carries `attachment`.
+// List views only render the name and (for the initiative board) the combat
+// subset of the sheet. Shipping the whole opaque `character` here drags along
+// `appearance` — a base64 image data URL up to 2 MB per character — which
+// bloated /api/charlist and, once added, every initiative board poll. Trim to
+// the fields the list + board actually read (see CLAUDE.md board subset).
+const BOARD_CHAR_FIELDS = [
+    'name', 'ac', 'hp', 'maxHp', 'tempHp', 'dex', 'speed', 'color',
+    'strSave', 'dexSave', 'conSave', 'intSave', 'wisSave', 'chaSave'
+]
+const trimCharacter = (character) => {
+    const out = {}
+    for (const k of BOARD_CHAR_FIELDS) if (character && k in character) out[k] = character[k]
+    return out
+}
 const filterCharacterListe = (liste) => {
     return liste.map((item) => ({
-        _id: item._id, character: item.character, npc: item.npc, primary: item.primary
+        _id: item._id, character: trimCharacter(item.character), npc: item.npc, primary: item.primary
     }))
 }
 

--- a/api/character/index.js
+++ b/api/character/index.js
@@ -427,18 +427,20 @@ const deleteOwnCharacter = async (req, res) => {
     res.sendStatus(200)
 }
 
-// List views only render the name and (for the initiative board) the combat
-// subset of the sheet. Shipping the whole opaque `character` here drags along
-// `appearance` — a base64 image data URL up to 2 MB per character — which
-// bloated /api/charlist and, once added, every initiative board poll. Trim to
-// the fields the list + board actually read (see CLAUDE.md board subset).
-const BOARD_CHAR_FIELDS = [
+// List views only render a small slice of the sheet. Shipping the whole opaque
+// `character` here drags along `appearance` — a base64 image data URL up to
+// 2 MB per character — which bloated /api/charlist and, once added, every
+// initiative board poll. Trim to the fields the list actually reads: the
+// combat subset the initiative board uses (see CLAUDE.md) plus the columns the
+// character-list page shows (classLevel/race/level/playerName).
+const LIST_CHAR_FIELDS = [
     'name', 'ac', 'hp', 'maxHp', 'tempHp', 'dex', 'speed', 'color',
-    'strSave', 'dexSave', 'conSave', 'intSave', 'wisSave', 'chaSave'
+    'strSave', 'dexSave', 'conSave', 'intSave', 'wisSave', 'chaSave',
+    'classLevel', 'race', 'level', 'playerName'
 ]
 const trimCharacter = (character) => {
     const out = {}
-    for (const k of BOARD_CHAR_FIELDS) if (character && k in character) out[k] = character[k]
+    for (const k of LIST_CHAR_FIELDS) if (character && k in character) out[k] = character[k]
     return out
 }
 const filterCharacterListe = (liste) => {

--- a/api/initiative/index.js
+++ b/api/initiative/index.js
@@ -7,6 +7,27 @@ let playerTurn = 0
 let colorMarkerIndex = 0
 let colorMarkers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
+// The board only ever reads this combat subset of a character (see the
+// initiative note in CLAUDE.md). Full sheets carry `appearance` — a base64
+// image up to 2 MB — which otherwise gets stored in `master` and re-shipped on
+// every board GET (~1.7 MB) and PUT (~575 KB). Trim on the way in so an entry
+// never drags its image onto the board.
+const BOARD_CHAR_FIELDS = [
+    'name', 'ac', 'hp', 'maxHp', 'tempHp', 'dex', 'speed', 'color',
+    'strSave', 'dexSave', 'conSave', 'intSave', 'wisSave', 'chaSave'
+]
+const trimBoardCharacter = (character) => {
+    const out = {}
+    for (const k of BOARD_CHAR_FIELDS) if (character && k in character) out[k] = character[k]
+    return out
+}
+// Trim the `character` of a single board entry in place (leaves non-character
+// board fields — turnId, initiative, colorMarker, hidden, … — untouched).
+const trimEntry = (p) => {
+    if (p && p.character) p.character = trimBoardCharacter(p.character)
+    return p
+}
+
 // A monster (not a player character or plain NPC) counts as dead once its HP
 // hits 0. Dead monsters are pushed to the bottom of the order and skipped.
 const isDeadMonster = (p) => {
@@ -38,7 +59,7 @@ const reorderDeadMonsters = () => {
 // set master
 // REQUIRES MASTER
 const setPlayer = (req, res) => {
-    master = req.body.player
+    master = Array.isArray(req.body.player) ? req.body.player.map(trimEntry) : req.body.player
     setTurn()
     updatePlayerData()
     res.sendStatus(200)
@@ -97,7 +118,7 @@ const updateMaster = (req, res) => {
             try {
                 for (let i = 0; i < master.length; i++) {
                     if (master[i].turnId === p.turnId) {
-                        master[i] = p
+                        master[i] = trimEntry(p)
                         master[i].isMaster = true
                         break
                     }
@@ -124,7 +145,7 @@ const addMaster = (req, res) => {
                 colorMarkerIndex = (colorMarkerIndex + 1) % colorMarkers.length
             }
 
-            master.push(p)
+            master.push(trimEntry(p))
             setTurn()
             updatePlayerData()
         } catch (_) {

--- a/api/monster/index.js
+++ b/api/monster/index.js
@@ -29,6 +29,19 @@ const getMonsterList = async (req, res) => {
     res.send(filterMonsterListe(monList))
 }
 
+// Lean list for the initiative "add monster" modal and the encounter monster
+// picker: those only read the name + combat subset (monsterToCharacter) and a
+// name search. The full doc carries long text blobs (actions, senses,
+// languages, …) that made 400 monsters a heavy payload. Project at the DB so
+// the weight never leaves Mongo. The editor still uses the full /list.
+const getMonsterListLean = async (req, res) => {
+    const monList = await Monster.find({}, {
+        'monster.name': 1, 'monster.ac': 1, 'monster.hp': 1,
+        'monster.speed': 1, 'monster.stats.dex': 1, 'monster.saving': 1
+    }).sort({'monster.name': 1})
+    res.send(monList)
+}
+
 // REQUIRES MASTER OR ADMIN
 const deleteMonster = async (req, res) => {
     const charID = req.params.id
@@ -61,6 +74,7 @@ const filterMonster = (char) => {
 module.exports = {
     createMonster,
     getMonsterList,
+    getMonsterListLean,
     deleteMonster,
     saveMonster,
     getMonster

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "2.1",
+  "version": "2.2",
   "private": true,
   "license": "MIT",
   "dependencies": {

--- a/api/server.js
+++ b/api/server.js
@@ -20,7 +20,7 @@ const {
     setRound, getRound, deleteMaster, updateMaster, addMaster, deleteAllMaster,
     nextTurn, prevTurn
 } = require("./initiative");
-const {createMonster, getMonsterList, saveMonster, deleteMonster, getMonster} = require("./monster");
+const {createMonster, getMonsterList, getMonsterListLean, saveMonster, deleteMonster, getMonster} = require("./monster");
 const {createEncounter, getEncounterList, saveEncounter, deleteEncounter} = require("./encounter");
 const {getUserList, setAdmin, setMaster, setPassword} = require("./admin");
 const {getBookList, uploadBook, deleteBook, bookUpload} = require("./books");
@@ -183,6 +183,7 @@ app.get('/api/initiative/turn/prev', isAuth, isMaster, prevTurn)
 //
 app.get('/api/monster/new', isAuth, isMaster, createMonster)
 app.get('/api/monster/list', isAuth, isMaster, getMonsterList)
+app.get('/api/monster/list/lean', isAuth, isMaster, getMonsterListLean)
 app.put('/api/monster', isAuth, isMaster, saveMonster)
 app.delete('/api/monster/:id', isAuth, isMaster, deleteMonster)
 app.get('/api/monster/:id', isAuth, isMaster, getMonster)

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnd",
-  "version": "2.1",
+  "version": "2.2",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/Pages/encounter/encounter-entry.tsx
+++ b/web/src/Pages/encounter/encounter-entry.tsx
@@ -77,7 +77,7 @@ const App = (props: { m: EncounterType, u: () => void, e: boolean }) => {
     }
 
     useEffect(() => {
-        axios.get(process.env.REACT_APP_API_PREFIX + '/api/monster/list')
+        axios.get(process.env.REACT_APP_API_PREFIX + '/api/monster/list/lean')
             .then((data) => {
                 setMonsterList(data.data)
             })

--- a/web/src/Pages/encounter/encounter-entry.tsx
+++ b/web/src/Pages/encounter/encounter-entry.tsx
@@ -52,6 +52,7 @@ const App = (props: { m: EncounterType, u: () => void, e: boolean }) => {
     const [monsterList, setMonsterList] = useState<Monster[]>([])
 
     const cancelRef = React.useRef(null)
+    const didMount = React.useRef(false)
     const toast = useToast()
 
     const closePopup = () => setIsOpen(false)
@@ -86,6 +87,10 @@ const App = (props: { m: EncounterType, u: () => void, e: boolean }) => {
     }, []);
 
     useEffect(() => {
+        if (!didMount.current) {
+            didMount.current = true
+            return
+        }
         save()
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [encounter]);

--- a/web/src/Pages/initiative/add/add-encounter.tsx
+++ b/web/src/Pages/initiative/add/add-encounter.tsx
@@ -5,11 +5,13 @@ import "../initiative.css";
 import axios from "axios";
 import {EncounterMonster, EncounterType} from "../../encounter/encounter.type";
 import {buildEncounterInstances, monsterBoardEntry} from "./add.utils";
+import AddSkeletonRows from "./add-skeleton";
 
 const App = (props: {u: () => void}) => {
 
     const [data, setData] = useState<EncounterType[]>([]);
     const [values, setValue] = useState<EncounterType[]>([])
+    const [loading, setLoading] = useState(true)
 
     const search = (val: string) => {
         // @ts-ignore — encounter rows carry a `name`, not a `character.name`
@@ -50,6 +52,7 @@ const App = (props: {u: () => void}) => {
             })
             .catch(() => {
             })
+            .finally(() => setLoading(false))
     }
 
     const onAdd = (m: EncounterType) => {
@@ -80,8 +83,9 @@ const App = (props: {u: () => void}) => {
                     </Tr>
                 </Thead>
                 <Tbody>
+                    {loading && <AddSkeletonRows cols={2}/>}
                     {
-                        values.map((item, index) => (
+                        !loading && values.map((item, index) => (
                             <Tr key={index}>
                                 <Td><Text isTruncated maxW='11rem'>{item.name}</Text></Td>
                                 <Td>

--- a/web/src/Pages/initiative/add/add-monster.tsx
+++ b/web/src/Pages/initiative/add/add-monster.tsx
@@ -6,18 +6,20 @@ import {Player} from "../player.type";
 import axios from "axios";
 import {Monster} from "../../monster/monster.type";
 import {abilityModifier, applyHidden, filterByName, monsterBoardEntry, rollD20} from "./add.utils";
+import AddSkeletonRows from "./add-skeleton";
 
 const App = (props: {u: () => void}) => {
 
     const [data, setData] = useState<Player[]>([])
     const [values, setValue] = useState<Player[]>([])
+    const [loading, setLoading] = useState(true)
 
     const search = (val: string) => {
         setValue(structuredClone(filterByName(data, val)))
     }
 
     const getMonster = () => {
-        axios.get(process.env.REACT_APP_API_PREFIX + '/api/monster/list')
+        axios.get(process.env.REACT_APP_API_PREFIX + '/api/monster/list/lean')
             .then((d) => {
                 setValue([])
                 let monsters: Player[] = []
@@ -29,6 +31,7 @@ const App = (props: {u: () => void}) => {
             })
             .catch(() => {
             })
+            .finally(() => setLoading(false))
     }
 
     const onAdd = (m: Player) => {
@@ -62,8 +65,9 @@ const App = (props: {u: () => void}) => {
                     </Tr>
                 </Thead>
                 <Tbody>
+                    {loading && <AddSkeletonRows cols={3}/>}
                     {
-                        values.map((item, index) => (
+                        !loading && values.map((item, index) => (
                             <Tr key={index}>
                                 <Td><Text isTruncated maxW='11rem'>{item.character.name}</Text></Td>
                                 <Td><Switch onChange={(evt) => onHide(item, evt.currentTarget.checked)}/></Td>

--- a/web/src/Pages/initiative/add/add-npc.tsx
+++ b/web/src/Pages/initiative/add/add-npc.tsx
@@ -5,11 +5,13 @@ import "../initiative.css";
 import {Player} from "../player.type";
 import axios from "axios";
 import {abilityModifier, applyHidden, colorToMarker, filterByName, npcEntries, rollD20} from "./add.utils";
+import AddSkeletonRows from "./add-skeleton";
 
 const App = (props: {u: () => void}) => {
 
     const [data, setData] = useState<Player[]>([])
     const [values, setValue] = useState<Player[]>([])
+    const [loading, setLoading] = useState(true)
 
     const search = (val: string) => {
         setValue(structuredClone(filterByName(data, val)))
@@ -24,6 +26,7 @@ const App = (props: {u: () => void}) => {
             })
             .catch(() => {
             })
+            .finally(() => setLoading(false))
     }
 
     const onAdd = (p: Player) => {
@@ -60,8 +63,9 @@ const App = (props: {u: () => void}) => {
                     </Tr>
                 </Thead>
                 <Tbody>
+                    {loading && <AddSkeletonRows cols={3}/>}
                     {
-                        values.map((item, index) => (
+                        !loading && values.map((item, index) => (
                             <Tr key={index}>
                                 <Td><Text isTruncated maxW='11rem'>{item.character.name}</Text></Td>
                                 <Td><Switch onChange={(evt) => onHide(item, evt.currentTarget.checked)}/></Td>

--- a/web/src/Pages/initiative/add/add-player.tsx
+++ b/web/src/Pages/initiative/add/add-player.tsx
@@ -19,11 +19,13 @@ import "../initiative.css";
 import {Player} from "../player.type";
 import axios from "axios";
 import {colorToMarker, filterByName, playableEntries} from "./add.utils";
+import AddSkeletonRows from "./add-skeleton";
 
 const App = (props: {u: () => void}) => {
 
     const [data, setData] = useState<Player[]>([])
     const [values, setValue] = useState<Player[]>([])
+    const [loading, setLoading] = useState(true)
 
     const search = (val: string) => {
         setValue(structuredClone(filterByName(data, val)))
@@ -38,6 +40,7 @@ const App = (props: {u: () => void}) => {
             })
             .catch(() => {
             })
+            .finally(() => setLoading(false))
     }
 
     const onAdd = (p: Player) => {
@@ -69,8 +72,9 @@ const App = (props: {u: () => void}) => {
                     </Tr>
                 </Thead>
                 <Tbody>
+                    {loading && <AddSkeletonRows cols={3}/>}
                     {
-                        values.map((item, index) => (
+                        !loading && values.map((item, index) => (
                             <Tr key={index}>
                                 <Td>
                                     <HStack spacing='0.4rem'>

--- a/web/src/Pages/initiative/add/add-skeleton.tsx
+++ b/web/src/Pages/initiative/add/add-skeleton.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import {Skeleton, Td, Tr} from "@chakra-ui/react";
+
+// Wireframe rows shown in an add-tab's table body while its list is still
+// loading (the lists can be large — hundreds of monsters/characters).
+const AddSkeletonRows = ({cols, rows = 6}: {cols: number, rows?: number}) => (
+    <React.Fragment>
+        {Array.from({length: rows}).map((_, r) => (
+            <Tr key={r}>
+                {Array.from({length: cols}).map((_, c) => (
+                    <Td key={c}><Skeleton height='1.25rem'/></Td>
+                ))}
+            </Tr>
+        ))}
+    </React.Fragment>
+);
+
+export default AddSkeletonRows;

--- a/web/src/Pages/initiative/add/add.tsx
+++ b/web/src/Pages/initiative/add/add.tsx
@@ -14,7 +14,7 @@ const App = (props: {u: () => void}) => {
             </ModalHeader>
             <ModalCloseButton/>
             <ModalBody>
-                <Tabs>
+                <Tabs isLazy lazyBehavior='keepMounted'>
                     <TabList>
                         <Tab>Spieler</Tab>
                         <Tab>Monster</Tab>


### PR DESCRIPTION
## Why

Fully-filled character sheets embed the appearance image as a base64 data URL (up to 2 MB). It rode along with every list and board payload, making the initiative **add** modal and adding a combatant take **4-5s** in prod (confirmed via Firefox HAR):

- `POST /api/initiative/player` ~575 KB body
- `GET /api/initiative/master` ~1.7 MB response
- every `PUT /api/initiative/player` ~575 KB

…all just re-shipping images the board never displays.

## What

Each trim sits at the single point all callers route through:

- **`filterCharacterListe`** — trim `/api/charlist{,/me,/npc}` to the board subset (`name, ac, hp/maxHp/tempHp, dex, speed, color, *Save`). No more image in the add-player/npc lists or the character-list view.
- **`trimEntry` (initiative)** — strip `player.character` to the same subset on every write into the in-memory board (`setPlayer` / `addMaster` / `updateMaster`), so the board never stores an image and `GET master` / `PUT` stay lean end-to-end.
- **`/api/monster/list/lean`** — new DB-projected list for the add-monster modal and encounter picker. Full `/list` stays for the monster editor (which edits + saves the whole doc).

Net: add POST drops ~575 KB → ~200 bytes, board GET 1.7 MB → a few KB; the entry lands on the DM board in one fast round-trip.

### Frontend
- `Tabs isLazy` + `keepMounted` on the add modal → opening it fires **one** list fetch (active tab) instead of four; other tabs load on first open.
- Wireframe skeleton rows (`add-skeleton`) while each add tab's list loads.

### Also in this branch
- Fix: encounter tab no longer saved every card on open (per-card effect ran on mount).

## Tests
- `charlist` / monster-lean / board-entry trims asserted (drop `appearance`, keep the combat subset). API suites green.
- Bump to **2.2** (api + web).

## Notes
- Existing fat entries already in a live in-memory board stay fat until re-added/edited or a restart/reset; new adds are lean immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)