### PR TITLE
ci: modernize CodeQL workflow (v1 actions retired)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,28 +1,16 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '17 10 * * 4'
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -32,39 +20,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'typescript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+        include:
+          # JS and TS share one CodeQL analysis; build-mode none = no build step
+          # needed for interpreted languages.
+          - language: javascript-typescript
+            build-mode: none
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+        build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Does it need updating? Yes — it's currently broken.

The workflow pinned retired action versions, so every run hard-fails:
- `github/codeql-action/*@v1` — removed by GitHub **Jan 2023** (v2 deprecated Jan 2025; **v3** is current)
- `actions/checkout@v2` — EoL Node runtime

## Changes
- `codeql-action` init/analyze **v1 → v3**, `checkout` **v2 → v4**
- Collapse the `javascript` + `typescript` matrix into the combined **`javascript-typescript`** analysis (one run, not two)
- Drop `Autobuild` in favour of **`build-mode: none`** (JS/TS is interpreted — no build needed) and add the analysis `category`

## How to activate it
1. Merge this to `main` — the workflow triggers on push/PR to `main` and weekly (`cron`), so it runs automatically once on the default branch.
2. **Advanced vs Default setup:** this file *is* CodeQL "advanced setup". If **Settings → Code security → Code scanning → Default setup** is currently *enabled*, GitHub blocks the workflow with `default setup is enabled` — switch Default setup **off** (advanced replaces it). If it's off, nothing to do.
3. Results land under the repo's **Security → Code scanning** tab after the first run.
4. Needs GitHub Actions enabled and (for the SARIF upload) the `security-events: write` permission — already declared in the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)